### PR TITLE
dont try to build jar unless pushing to main

### DIFF
--- a/.github/workflows/build-snapshot-jar.yml
+++ b/.github/workflows/build-snapshot-jar.yml
@@ -11,8 +11,8 @@ name: Build LATEST Snapshot JAR
 on:
   push:
     branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+  #pull_request:
+  #  branches: [ "main" ]
 
 jobs:
   build:


### PR DESCRIPTION
We don't need to build the jar unless we're actually doing a release.  