### PR TITLE
Compile project on Java 11, build on 11, 17, 21

### DIFF
--- a/.github/workflows/build-snapshot-jar.yml
+++ b/.github/workflows/build-snapshot-jar.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
     
     - uses: actions/checkout@v3
-    - name: Set up JDK 18
+    - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
-        java-version: '18'
+        java-version: '11'
         distribution: 'temurin'
         # cache: maven
     - name: Build with Maven

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -15,27 +15,33 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  MAVEN_ARGS: -V -B --no-transfer-progress -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+
 jobs:
   build:
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 11, 17, 21 ]
+    name: 'Linux JDK ${{ matrix.java }}'
     runs-on: ubuntu-latest
-
     steps:
-    
-    - uses: actions/checkout@v3
-    - name: Set up JDK 18
-      uses: actions/setup-java@v3
-      with:
-        java-version: '18'
-        distribution: 'temurin'
-    - name: Build and test with Maven
-      env: 
-        POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
-      run:  |
-        mkdir ./test-output
-        mvn test
-    
-    
+      - name: 'Checkout'
+        uses: actions/checkout@v3
+      - name: 'Set up JDK ${{ matrix.java }}'
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java }}
+          cache: 'maven'
+      - name: Build and test with Maven
+        env:
+          POSTMAN_API_KEY: ${{ secrets.POSTMAN_API_KEY }}
+        run:  |
+          mkdir ./test-output
+          mvn ${MAVEN_ARGS} test
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+      - name: Update dependency graph
+        uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+target/
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,6 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>18</maven.compiler.source>
-    <maven.compiler.target>18</maven.compiler.target>
   </properties>
 
   <dependencies>
@@ -131,21 +129,14 @@
           <artifactId>maven-resources-plugin</artifactId>
           <version>3.3.1</version>
         </plugin>
-        <!--
-        <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-            </plugin>
-            -->
             <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.11.0</version>
-        <configuration>
-          <source>18</source>
-          <target>18</target>
-        </configuration>
+              <configuration>
+                <source>11</source>
+                <target>11</target>
+              </configuration>
       </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>

--- a/src/main/java/com/postman/collection/RequestAuth.java
+++ b/src/main/java/com/postman/collection/RequestAuth.java
@@ -129,7 +129,10 @@ public class RequestAuth extends CollectionElement {
     public enumAuthType getAuthType() {
 
         switch (type) {
-            case "apikey", "bearer": {
+            case "apikey": {
+                return enumAuthType.APIKEY;
+            }
+            case "bearer": {
                 return enumAuthType.APIKEY;
             }
             case "digest": {


### PR DESCRIPTION
Hi @bryancross ,

I've just found your library and it eases the work for my team. I would like to do some contributions if You accept.
First of all, I think it would be good if JPostman could be used with lower Java versions than 18.
I made some small changes to enable the compilation of JPostman with Java 11 (Java 8 compatibility can be achieved if we use something other than java.net.http.HttpClient).

I've modified the build file to build the application with JDK 11, 17, 21, just to make sure it's working with these.

You can see the output of the job in my forked repository [here](https://github.com/szatyinadam/JPostman/actions/runs/7017466150) or [here is the snapshot build](https://github.com/szatyinadam/JPostman/actions/runs/7017637953), but I do not have the Postman API key. That's why some of the tests fail, but it should work on your repository.

After this PR, I would like to work on the Maven Central publishing to be able to access JPostman as Maven dependency.